### PR TITLE
Fix the issue Expect scripts cause /tmp/_MEIxxxxxx to be left around.

### DIFF
--- a/scripts/vpn-connect.expect
+++ b/scripts/vpn-connect.expect
@@ -1,14 +1,17 @@
 #! /usr/bin/expect -f
 
 set timeout -1
+set exit_code 0
 
 spawn windscribe connect $env(WINDSCRIBE_LOCATION)
 
 expect {
-    "Please login to use Windscribe" { send_user "Not logged in\n"; exit 5 }
-    "Connected to*" { send_user "VPN connected\n"; exit 0 }
-    "Error adding route*" { send_user "Unable to connect\n"; exit 5 }
-    "Failed to connect" { send_user "Unable to connect\n"; exit 5 }
-    eof { send_user "Unexpected EOF\n"; exit 5 }
+    "Please login to use Windscribe" { send_user "Not logged in\n"; set exit_code 5 }
+    "Connected to*" { send_user "VPN connected\n"; set exit_code 0 }
+    "Error adding route*" { send_user "Unable to connect\n"; set exit_code 5 }
+    "Failed to connect" { send_user "Unable to connect\n"; set exit_code 5 }
+    eof { send_user "Unexpected EOF\n"; set exit_code 5 }
 }
 
+wait
+exit $exit_code

--- a/scripts/vpn-firewall.expect
+++ b/scripts/vpn-firewall.expect
@@ -1,14 +1,18 @@
 #! /usr/bin/expect -f
 
 set timeout 20
+set exit_code 0
 
 spawn windscribe firewall $env(WINDSCRIBE_FIREWALL)
 
 expect {
-    "Please login to use Windscribe" { send_user "Not logged in\n"; exit 5 }
-    "Invalid firewall mode*" { send_user "Invalid LAN bypass mode\n"; exit 5 }
-    "Firewall Enabled" { send_user "Firewall is on\n"; exit 0 }
-    "Firewall Disabled" { send_user "Firewall is off\n"; exit 0 }
-    eof { send_user "Unexpected EOF\n"; exit 5 }
+    "Please login to use Windscribe" { send_user "Not logged in\n"; set exit_code 5 }
+    "Invalid firewall mode*" { send_user "Invalid LAN bypass mode\n"; set exit_code 5 }
+    "Firewall Enabled" { send_user "Firewall is on\n"; set exit_code 0 }
+    "Firewall Disabled" { send_user "Firewall is off\n"; set exit_code 0 }
+    "Firewall mode changed to: auto" { send_user "Firewall set to auto\n"; set exit_code 0 }
+    eof { send_user "Unexpected EOF\n"; set exit_code 5 }
 }
 
+wait
+exit $exit_code

--- a/scripts/vpn-health-check.expect
+++ b/scripts/vpn-health-check.expect
@@ -1,12 +1,15 @@
 #! /usr/bin/expect -f
 
 set timeout 20
+set exit_code 0
 
 spawn windscribe status
 
 expect {
-    "DISCONNECTED" { send_user "Health BAD\n"; exit 5 }
-    "CONNECTED" { send_user "Health OK\n"; exit 0 }
-    eof { send_user "Health BAD\n"; exit 5 }
+    "DISCONNECTED" { send_user "Health BAD\n"; set exit_code 5 }
+    "CONNECTED" { send_user "Health OK\n"; set exit_code 0 }
+    eof { send_user "Health BAD\n"; set exit_code 5 }
 }
 
+wait
+exit $exit_code

--- a/scripts/vpn-lanbypass.expect
+++ b/scripts/vpn-lanbypass.expect
@@ -1,13 +1,16 @@
 #! /usr/bin/expect -f
 
 set timeout 20
+set exit_code 0
 
 spawn windscribe lanbypass $env(WINDSCRIBE_LANBYPASS)
 
 expect {
-    "Please login to use Windscribe" { send_user "Not logged in\n"; exit 5 }
-    "Invalid LAN bypass mode*" { send_user "Invalid LAN bypass mode\n"; exit 5 }
-    "LAN bybass set to*" { send_user "LAN bypass set\n"; exit 0 }
-    eof { send_user "Unexpected EOF\n"; exit 5 }
+    "Please login to use Windscribe" { send_user "Not logged in\n"; set exit_code 5 }
+    "Invalid LAN bypass mode*" { send_user "Invalid LAN bypass mode\n"; set exit_code 5 }
+    "LAN bybass set to*" { send_user "LAN bypass set\n"; set exit_code 0 }
+    eof { send_user "Unexpected EOF\n"; set exit_code 5 }
 }
 
+wait
+exit $exit_code

--- a/scripts/vpn-login.expect
+++ b/scripts/vpn-login.expect
@@ -1,13 +1,14 @@
 #! /usr/bin/expect -f
 
 set timeout 20
+set exit_code 0
 
 spawn windscribe login
 
 expect {
-    "Already Logged in" { send_user "Loggin Successful\n"; exit 0 }
+    "Already Logged in" { send_user "Loggin Successful\n"; set exit_code 0 }
     "Username:" { send -- "$env(WINDSCRIBE_USERNAME)\r" }
-    eof { send_user "Unexpected EOF\n"; exit 5 }
+    eof { send_user "Unexpected EOF\n"; set exit_code 5 }
 }
 
 expect "Password:"
@@ -15,8 +16,10 @@ expect "Password:"
 send -- "$env(WINDSCRIBE_PASSWORD)\r"
 
 expect {
-    "API Error*" { send_user "Login Failed\n"; exit 5 }
-    "Logged In" { send_user "Login Successful\n"; exit 0 }
-    eof { send_user "Unexpected EOF\n"; exit 5 }
+    "API Error*" { send_user "Login Failed\n"; set exit_code 5 }
+    "Logged In" { send_user "Login Successful\n"; set exit_code 0 }
+    eof { send_user "Unexpected EOF\n"; set exit_code 5 }
 }
 
+wait
+exit $exit_code

--- a/scripts/vpn-port.expect
+++ b/scripts/vpn-port.expect
@@ -1,13 +1,16 @@
 #! /usr/bin/expect -f
 
 set timeout 20
+set exit_code 0
 
 spawn windscribe port $env(WINDSCRIBE_PORT)
 
 expect {
-    "Please login to use Windscribe" { send_user "Not logged in\n"; exit 5 }
-    "Invalid port*" { send_user "Port is invalid\n"; exit 5 }
-    "Default port changed*" { send_user "Port set successfully\n"; exit 0 }
-    eof { send_user "Enexpected EOF\n"; exit 5 }
+    "Please login to use Windscribe" { send_user "Not logged in\n"; set exit_code 5 }
+    "Invalid port*" { send_user "Port is invalid\n"; set exit_code 5 }
+    "Default port changed*" { send_user "Port set successfully\n"; set exit_code 0 }
+    eof { send_user "Enexpected EOF\n"; set exit_code 5 }
 }
 
+wait
+exit $exit_code

--- a/scripts/vpn-protocol.expect
+++ b/scripts/vpn-protocol.expect
@@ -1,13 +1,16 @@
 #! /usr/bin/expect -f
 
 set timeout 20
+set exit_code 0
 
 spawn windscribe protocol $env(WINDSCRIBE_PROTOCOL)
 
 expect {
-    "Please login to use Windscribe" { send_user "Not logged in\n"; exit 5 }
-    "Invalid protocol*" { send_user "Protocol is invalid\n"; exit 5 }
-    "Default protocol changed*" { send_user "Protocol set successfully\n"; exit 0 }
-    eof { send_user "Enexpected EOF\n"; exit 5 }
+    "Please login to use Windscribe" { send_user "Not logged in\n"; set exit_code 5 }
+    "Invalid protocol*" { send_user "Protocol is invalid\n"; set exit_code 5 }
+    "Default protocol changed*" { send_user "Protocol set successfully\n"; set exit_code 0 }
+    eof { send_user "Enexpected EOF\n"; set exit_code 5 }
 }
 
+wait
+exit $exit_code


### PR DESCRIPTION
I used your docker-windscribe to run a VPN in a container. After a couple of weeks, I found the size of the container increased by several GB. Eventually I chased it down to the /tmp folder, which contained many _MEIxxxxxx folders.

It turned out they were created by windscribe program. Windscribe is created with Pyinstalled as a one-file program. Every time it runs, it extracts support files into a temporary folder /tmp/_MEIxxxxxx, where xxxxxx is a random generated name. Once windscribe finishes, it is supposed to remove the temporary folder.

However, all the Expect scripts are written to exit immediately once a match is found. That also kills any child processes spawned with "spawn windcribe command". Since windscribe process is killed before it has the chance to clean up, /temp/_MEIxxxxxx folders are left around to eat up storage space.

My solution to this issue is to modify Expect scripts in a way which don't exit immediately but set an exit code. Later the script waits for child process to finish, then exits with the exit code.